### PR TITLE
feat: always scan shared ~/.agents/skills/ directory without agent de…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-skills",
-  "version": "0.1.4",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-skills",
-      "version": "0.1.4",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.3.0",

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -1,11 +1,17 @@
 use crate::models::agent::AgentConfig;
 use crate::paths;
-use crate::registry::loader::{detect_agents as detect_agents_impl, load_agent_configs};
+use crate::registry::loader::{
+    detect_agents as detect_agents_impl, load_agent_configs, shared_agent_config,
+};
 
 #[tauri::command]
 pub async fn list_agents() -> Result<Vec<AgentConfig>, String> {
     tauri::async_runtime::spawn_blocking(|| {
-        load_agent_configs(&paths::agents_dir()).map_err(|e| e.to_string())
+        let mut agents = load_agent_configs(&paths::agents_dir()).map_err(|e| e.to_string())?;
+        // Always include the virtual shared agent
+        agents.push(shared_agent_config());
+        agents.sort_by(|a, b| a.slug.cmp(&b.slug));
+        Ok(agents)
     })
     .await
     .map_err(|e| format!("task failed: {e}"))?
@@ -15,7 +21,13 @@ pub async fn list_agents() -> Result<Vec<AgentConfig>, String> {
 pub async fn detect_agents() -> Result<Vec<AgentConfig>, String> {
     tauri::async_runtime::spawn_blocking(|| {
         let configs = load_agent_configs(&paths::agents_dir()).map_err(|e| e.to_string())?;
-        Ok(detect_agents_impl(&configs))
+        let mut agents = detect_agents_impl(&configs);
+        // Ensure the shared agent is always present (detect_agents_impl already
+        // appends it via shared_agent_config(), but we guarantee uniqueness here)
+        if !agents.iter().any(|a| a.slug == "shared") {
+            agents.push(shared_agent_config());
+        }
+        Ok(agents)
     })
     .await
     .map_err(|e| format!("task failed: {e}"))?

--- a/src-tauri/src/commands/marketplace.rs
+++ b/src-tauri/src/commands/marketplace.rs
@@ -61,6 +61,9 @@ pub async fn install_from_marketplace(
     skill: MarketplaceSkill,
     target_agents: Vec<String>,
 ) -> Result<(), String> {
+    if target_agents.iter().any(|a| a == "shared") {
+        return Err("Cannot install directly to the shared skills directory. Install to a specific agent instead.".to_string());
+    }
     // Offload the heavy git clone + file scan to a blocking thread
     // so the Tauri IPC channel stays responsive for UI updates
     tauri::async_runtime::spawn_blocking(move || {

--- a/src-tauri/src/commands/repos.rs
+++ b/src-tauri/src/commands/repos.rs
@@ -491,6 +491,9 @@ pub async fn install_repo_skill(
     skill_id: String,
     target_agents: Vec<String>,
 ) -> Result<(), String> {
+    if target_agents.iter().any(|a| a == "shared") {
+        return Err("Cannot install directly to the shared skills directory. Install to a specific agent instead.".to_string());
+    }
     tauri::async_runtime::spawn_blocking(move || {
         install_repo_skill_sync(repo_id_param, skill_id, target_agents)
     })

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -49,6 +49,9 @@ pub async fn scan_agent_skills(agent_slug: String) -> Result<Vec<Skill>, String>
 #[tauri::command]
 pub async fn install_skill(source: SkillSource, target_agents: Vec<String>) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
+        if target_agents.iter().any(|a| a == "shared") {
+            return Err("Cannot install directly to the shared skills directory. Install to a specific agent instead.".to_string());
+        }
         let agents = load_detected_agents()?;
         match source {
             SkillSource::LocalPath { path } => {
@@ -88,6 +91,9 @@ pub async fn install_skill(source: SkillSource, target_agents: Vec<String>) -> R
 #[tauri::command]
 pub async fn uninstall_skill(skill_id: String, agent_slug: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
+        if agent_slug == "shared" {
+            return Err("Cannot uninstall from the shared skills directory directly. Uninstall from the specific agent instead.".to_string());
+        }
         let agents = load_detected_agents()?;
         uninstall_skill_impl(&skill_id, &agent_slug, &agents).map_err(|e| e.to_string())
     })
@@ -108,6 +114,9 @@ pub async fn uninstall_skill_all(skill_id: String) -> Result<(), String> {
 #[tauri::command]
 pub async fn sync_skill(skill_id: String, target_agents: Vec<String>) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
+        if target_agents.iter().any(|a| a == "shared") {
+            return Err("Cannot sync to the shared skills directory. Sync to a specific agent instead.".to_string());
+        }
         let agents = load_detected_agents()?;
         let source = resolve_skill_source(&skill_id, &agents)?;
         install_skill_from_path(&source, &target_agents, &agents).map_err(|e| e.to_string())?;
@@ -225,6 +234,9 @@ pub async fn install_from_git(
     target_agents: Vec<String>,
 ) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
+        if target_agents.iter().any(|a| a == "shared") {
+            return Err("Cannot install directly to the shared skills directory. Install to a specific agent instead.".to_string());
+        }
         let agents = load_detected_agents()?;
         install_skill_from_git(&repo_url, &skill_relative_path, &target_agents, &agents)
             .map_err(|e| e.to_string())?;

--- a/src-tauri/src/registry/loader.rs
+++ b/src-tauri/src/registry/loader.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
+use crate::installer::install::shared_skills_dir;
 use crate::models::agent::AgentConfig;
 
 #[derive(Debug, Error)]
@@ -46,8 +47,30 @@ pub fn load_agent_configs(dir: &Path) -> Result<Vec<AgentConfig>, RegistryError>
     Ok(configs)
 }
 
+/// Return the virtual "shared" agent config that always exists.
+///
+/// This represents the canonical `~/.agents/skills/` directory and is always
+/// considered "detected", so skills in the shared directory are discoverable
+/// and manageable even when no third-party AI coding agent is installed.
+pub fn shared_agent_config() -> AgentConfig {
+    let shared_dir = shared_skills_dir();
+    AgentConfig {
+        slug: "shared".to_string(),
+        name: "Shared Skills".to_string(),
+        enabled: true,
+        detected: true,
+        global_paths: vec![shared_dir.to_string_lossy().to_string()],
+        ..Default::default()
+    }
+}
+
 pub fn detect_agents(configs: &[AgentConfig]) -> Vec<AgentConfig> {
-    configs.iter().map(detect_agent).collect()
+    let mut agents: Vec<AgentConfig> = configs.iter().map(detect_agent).collect();
+    // Always append the virtual "shared" agent so the shared skills directory
+    // is always represented in the agent list, regardless of which third-party
+    // agents are installed.
+    agents.push(shared_agent_config());
+    agents
 }
 
 fn detect_agent(config: &AgentConfig) -> AgentConfig {

--- a/src-tauri/src/scanner/engine.rs
+++ b/src-tauri/src/scanner/engine.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
+use crate::installer::install::{read_provenance, shared_skills_dir};
 use crate::models::agent::AgentConfig;
-use crate::installer::install::read_provenance;
 use crate::models::skill::{Skill, SkillInstallation, SkillScope, SkillSource};
 use crate::parser::skillmd::parse_skill_md_file;
 
@@ -92,10 +92,11 @@ fn is_symlink(path: &Path) -> bool {
 /// Strategy:
 /// 1. Scan each agent's own skill directories (global_paths)
 /// 2. Scan each agent's additional_readable_paths as inherited installations
-/// 3. Resolve symlinks to get canonical path
-/// 4. Merge by directory name (dedup key) — same name = same skill
-/// 5. Track per-agent installations with symlink/inherited metadata
-/// 6. Upgrade scope to SharedGlobal if installed in >1 agent
+/// 3. Always scan ~/.agents/skills/ (canonical shared directory) as a virtual "shared" agent
+/// 4. Resolve symlinks to get canonical path
+/// 5. Merge by directory name (dedup key) — same name = same skill
+/// 6. Track per-agent installations with symlink/inherited metadata
+/// 7. Upgrade scope to SharedGlobal if installed in >1 agent
 pub fn scan_all_skills(configs: &[AgentConfig]) -> Result<Vec<Skill>, ScannerError> {
     let mut dedup: HashMap<String, Skill> = HashMap::new();
     let provenance = read_provenance();
@@ -125,6 +126,28 @@ pub fn scan_all_skills(configs: &[AgentConfig]) -> Result<Vec<Skill>, ScannerErr
                 &mut dedup,
                 &provenance,
             )?;
+        }
+    }
+
+    // Pass 3: Always scan the canonical shared skills directory (~/.agents/skills/)
+    // This ensures skills are discoverable and manageable even when no AI coding agent
+    // is installed or detected on the system. Skills found here are associated with a
+    // virtual "shared" agent that is always present.
+    {
+        let shared_dir = shared_skills_dir();
+        if shared_dir.exists() || fs::create_dir_all(&shared_dir).is_ok() {
+            let shared_agent = AgentConfig {
+                slug: "shared".to_string(),
+                name: "Shared Skills".to_string(),
+                enabled: true,
+                detected: true,
+                global_paths: vec![shared_dir.to_string_lossy().to_string()],
+                ..Default::default()
+            };
+            // Only scan if the directory has entries (avoid empty scan noise)
+            if shared_dir.read_dir().map(|mut d| d.next().is_some()).unwrap_or(false) {
+                scan_skill_md_root(&shared_dir, &shared_agent, &mut dedup, &provenance)?;
+            }
         }
     }
 

--- a/src/components/SkillAgentList.tsx
+++ b/src/components/SkillAgentList.tsx
@@ -76,24 +76,34 @@ export const SkillAgentList = memo(function SkillAgentList({
         const busyOp = busyAgents.get(key);
         const actionLabel = hasLocal ? t("marketplace.sync") : t("marketplace.install");
 
+        // The "shared" virtual agent represents the canonical ~/.agents/skills/ directory.
+        // It is read-only in the UI: no install or uninstall actions are shown because
+        // it is the central repository. Users should install/uninstall from specific
+        // agents (which creates/removes symlinks into the canonical directory).
+        const isShared = agent.slug === "shared";
+
         return (
           <AgentRow
             key={agent.slug}
             name={agent.name}
-            status={status}
+            status={isShared ? "installed" : status}
             path={installation?.path}
             tags={sourceTag ? (
               <span className="text-[10px] text-muted-foreground/60 shrink-0">
                 {t("skills.via", { name: sourceTag })}
               </span>
+            ) : isShared && skill ? (
+              <span className="text-[10px] text-muted-foreground/60 shrink-0">
+                {t("skills.sharedDirectory")}
+              </span>
             ) : undefined}
-            onUninstall={!readOnly && isDirect && skill ? () => onUninstall(skill.id, agent.slug) : undefined}
-            onInstall={readOnly ? undefined : () => onInstall([agent.slug])}
+            onUninstall={!readOnly && isDirect && skill && !isShared ? () => onUninstall(skill.id, agent.slug) : undefined}
+            onInstall={readOnly || isShared ? undefined : () => onInstall([agent.slug])}
             uninstallTitle={`${t("skills.uninstall")} ${agent.name}`}
-            installLabel={actionLabel}
+            installLabel={isShared ? t("skills.available") : actionLabel}
             installTitle={`${actionLabel} → ${agent.name}`}
             revealTitle={t("skills.revealInFinder")}
-            disabled={readOnly || anyBusy}
+            disabled={readOnly || anyBusy || isShared}
             action={busyOp ? (
               <span className="shrink-0 inline-flex items-center gap-1 text-[10px] text-muted-foreground">
                 <Loader2 className="size-2.5 animate-spin" />

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -90,6 +90,7 @@ const en = {
     install: "Install",
     sync: "Sync",
     uninstall: "Uninstall",
+    available: "Available",
     // Actions
     actions: "Actions",
     editSkillMd: "Edit SKILL.md",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -90,6 +90,7 @@ const zhCN = {
     install: "安装",
     sync: "同步",
     uninstall: "卸载",
+    available: "可用",
     // Actions
     actions: "操作",
     editSkillMd: "编辑 SKILL.md",


### PR DESCRIPTION
…tection

Add Pass 3 in scanner to always scan the canonical shared skills directory (~/.agents/skills/) as a virtual 'shared' agent. This ensures skills are discoverable and manageable even when no AI coding agent is installed or detected on the system.

Key changes:
- scanner/engine.rs: Add Pass 3 that always scans shared directory
- registry/loader.rs: Add shared_agent_config() always-detected agent
- commands/agents.rs: Include shared agent in list/detect commands
- commands/skills/marketplace/repos: Guard against install/uninstall to/from shared agent (read-only canonical store)
- components/SkillAgentList.tsx: Shared agent shown as read-only with 'Available' label, no install/uninstall actions
- i18n: Add 'available' translation key